### PR TITLE
Fix for empty string returning true during validation

### DIFF
--- a/src/luhn.js
+++ b/src/luhn.js
@@ -8,10 +8,6 @@ module.exports = (function(){
 			, calc
 			, calc2;
 
-			if (length === 0){
-				return true;
-			}
-
 			if (!/^[0-9]+$/.test(trimmed)) {
 				return false;
 			}

--- a/tests/luhn-tests.js
+++ b/tests/luhn-tests.js
@@ -167,5 +167,10 @@ describe("Luhn Validation", function(){
 			var number = "00000000000000";
 			luhn.validate(number).should.be.false;
 		});
+
+		it("should return false if passed an empty string", function(){
+			var number = "";
+			luhn.validate(number).should.be.false;
+		});
 	});
 });


### PR DESCRIPTION
Problem: passing the value `''` to `validate()` results in a return value of `true`.

Solution: remove a length check that was returning `true` for a length of 0.

NOTE: I was really trying to find a reason as to why you would want to return `true` for an empty string but I couldn't think of a reason. I concluded that this was possibly leftover code that was no longer needed. (`git blame` showed it being added over four years ago)

Thanks for publishing and maintaing a great helper library!